### PR TITLE
SIN-97 envio de formulario a dos rutas

### DIFF
--- a/src/modules/dashboard/components/TarjetaUltimasCargas.vue
+++ b/src/modules/dashboard/components/TarjetaUltimasCargas.vue
@@ -11,8 +11,7 @@ import useEventsBus from "../../../layout/eventBus"
  * @var array<boolean, string, array>
  */
 const { bus } = useEventsBus()
-const { fetchTanksSalidas, getTanquesInSalida } = useDepartureTank()
-const departureList = computed(() => getTanquesInSalida())
+const { fetchTanksSalidas } = useDepartureTank()
 const { addToast } = useToast()
 let dataResult = ref([])
 let loadData = ref(true)
@@ -25,6 +24,7 @@ let loadData = ref(true)
  */
 const setDataFromResult = (data) => {
   dataResult.value = data
+  loadData.value = false
 }
 
 /**
@@ -34,7 +34,6 @@ const setDataFromResult = (data) => {
  *  en la cual guarda un mensaje para visualizar en la interfaz.
  */
 const fecthInformationOnTanksLastDepartures = async () => {
-  loadData.value = true
   try {
     const res = await fetchTanksSalidas()
     const { data, status } = res
@@ -43,7 +42,6 @@ const fecthInformationOnTanksLastDepartures = async () => {
     // Si el código de estatus es diferente de 200 se marcara un error 
     if (status == 200) {
       setDataFromResult(data)
-      loadData.value = false
     } else {
       addToast({
         message: {
@@ -53,7 +51,6 @@ const fecthInformationOnTanksLastDepartures = async () => {
           component:"TarjetaUltimasCargas - fecthInformationOnTanksLastDepartures()"
         },
       });
-      loadData.value = false
     }
   } catch (error) {
     // En caso de tener error establece un mensaje de error
@@ -65,7 +62,6 @@ const fecthInformationOnTanksLastDepartures = async () => {
         component:"TarjetaUltimasCargas | Catch - fecthInformationOnTanksLastDepartures()"
       },
     });
-    loadData.value = false
   }
 }
 
@@ -80,14 +76,7 @@ watch(() => bus.value.get('reloadData'), (val) => {
  *  para la obtencion de nueva información.
  */
 onMounted(() => {
-  //Condicional para verificar existencia de información en el store
-  if (departureList.value.length != 0) {
-    // Establece la información del store
-    setDataFromResult(departureList.value)
-  } else {
-    // Realiza la petición al servidor
-    fecthInformationOnTanksLastDepartures()
-  }
+  fecthInformationOnTanksLastDepartures()
 })
 </script>
 <template>

--- a/src/modules/entries/components/create.vue
+++ b/src/modules/entries/components/create.vue
@@ -31,7 +31,7 @@ const openModal = () => {
     isOpen.value = true
 }
 
-const { agregarTanqueEspera, getCountTanquesEspera } = useWaitTank()
+const { agregarTanqueEspera, getCountTanquesEspera,addEntryTank } = useWaitTank()
 
 const tanksTypes = [
     { id: 1, name: 'Sencillo', sufix: '', unavailable: false },
@@ -82,7 +82,7 @@ async function onSubmit() {
     entryForm.reporte24 = format(new Date(), 'yyyy-MM-dd')
     entryForm.reporte05 = format(new Date(), 'yyyy-MM-dd')
 
-    const { data, status } = await agregarTanqueEspera({
+    var body = {
         posicion: entryForm.posicion,
         atId: entryForm.atId,
         atTipo: entryForm.atTipo.id,
@@ -95,7 +95,15 @@ async function onSubmit() {
         fechaEntrada: entryForm.fechaEntrada,
         reporte24: entryForm.reporte24,
         reporte05: entryForm.reporte05,
-    })
+    }
+    
+    submitWaitTank(body)
+    submitEntryTank(body)
+
+}
+
+async function submitWaitTank (body){
+    const { data, status } = await agregarTanqueEspera(body)
     if (status == 200) {
         loader.value = false
         emit("successRegistration", true);
@@ -105,6 +113,33 @@ async function onSubmit() {
             message: {
                 title: "Éxito!",
                 message: `Se agregó el tanque ${data.atName} a la lista de espera.`,
+                type: "success"
+            },
+        });
+    } else {
+        loader.value = false
+        addToast({
+            message: {
+                title: "¡Error!",
+                message: data,
+                type: "error",
+                component: "create - onSubmit()"
+            },
+        });
+    }
+}
+
+async function submitEntryTank(body){
+    const { data, status } = await addEntryTank(body)
+    if (status == 200) {
+        loader.value = false
+        emit("successRegistrationEntryTank", true);
+        resetForm()
+        closeModal()
+        addToast({
+            message: {
+                title: "Éxito!",
+                message: `Se agregó el tanque ${data.atName} a la lista de entrada.`,
                 type: "success"
             },
         });

--- a/src/modules/entries/views/index.vue
+++ b/src/modules/entries/views/index.vue
@@ -6,12 +6,14 @@ import useTank from '../../tanques/composables/useTanque'
 import CreateEntry from "../components/create.vue"
 import { format } from 'date-fns'
 import { es } from 'date-fns/locale'
+import useEventsBus from "../../../layout/eventBus"
 
 /**
  * Declaración de los atributos que son asignables.
  * 
  * @var array<boolean, string, array>
  */
+ const { bus } = useEventsBus()
 const { fetchEntriesTanks, eliminarTanque, getTanksEntries } = useTank()
 const tanksList = computed(() => getTanksEntries())
 const { addToast } = useToast()
@@ -93,6 +95,10 @@ const setTipo = (categoria) => {
     }
 }
 
+watch(() => bus.value.get('successRegistrationEntryTank'), (val) => {
+    fetchDataEntriesTanks(dateToUse.value)
+})
+
 /**
  *  Al montar el componente evalua la disponibilidad y existencia de la información
  *  previamente almacenada en el store, en caso de existir @var tanksList sera asignado,
@@ -105,7 +111,6 @@ onMounted(() => {
         // Establece la información del store
         setDataFromResult(tanksList.value)
     } else {
-        console.log(dateToUse.value)
         // Realiza la petición al servidor
         fetchDataEntriesTanks(dateToUse.value)
     }

--- a/src/modules/tanques/components/TableEspera.vue
+++ b/src/modules/tanques/components/TableEspera.vue
@@ -1,7 +1,6 @@
 <script setup>
 //Importación de recursos
 import { ref, onMounted, computed, watch } from "vue"
-import { useRouter } from "vue-router"
 import EditIcon from "../../../assets/icons/edit.svg"
 import DeleteIcon from "../../../assets/icons/trash-can-solid.svg"
 import CallIcon from "../../../assets/icons/call.svg"
@@ -40,7 +39,7 @@ const deleteTankFromList = async (item) => {
     // Valida de acuerdo al estatus de la petición
     // Si el código de estatus es diferente de 200 se marcara un error 
     if (status == 200) {
-      loadDataFunction()
+      fetchDataTankWaitingList()
       addToast({
         message: {
           title: "Éxito!",
@@ -129,7 +128,6 @@ const moveTank = async (item) => {
  *  en la cual guarda un mensaje para visualizar en la interfaz.
  */
 const fetchDataTankWaitingList = async () => {
-  loadData.value = true
   try {
     const res = await fetchTanksInEspera()
     const { data, status } = res
@@ -138,7 +136,6 @@ const fetchDataTankWaitingList = async () => {
     // Si el código de estatus es diferente de 200 se marcara un error 
     if (status == 200) {
       setDataFromResult(data)
-      loadData.value = false
     } else {
       addToast({
         message: {
@@ -148,7 +145,6 @@ const fetchDataTankWaitingList = async () => {
           component: "TableEspera - fetchDataTankWaitingList()"
         },
       });
-      loadData.value = false
     }
   } catch (error) {
     // En caso de tener error establece un mensaje de error
@@ -159,12 +155,9 @@ const fetchDataTankWaitingList = async () => {
         type: "error",
         component: "TableEspera | Catch - fetchDataTankWaitingList()"
       },
-    });
-    loadData.value = false
+    })
   }
 }
-
-const router = useRouter();
 
 const editTanque = (item) => {
   // editar tanque
@@ -202,17 +195,6 @@ function setConector(conector) {
   }
 }
 
-const loadDataFunction = () => {
-  //Condicional para verificar existencia de información en el store
-  if (waitingList.value.length != 0) {
-    // Establece la información del store
-    setDataFromResult(waitingList.value)
-  } else {
-    // Realiza la petición al servidor
-    fetchDataTankWaitingList()
-  }
-}
-
 /**
  *  Al montar el componente evalua la disponibilidad y existencia de la información
  *  previamente almacenada en el store, en caso de existir @var waitingList sera asignado,
@@ -220,7 +202,7 @@ const loadDataFunction = () => {
  *  para la obtencion de nueva información.
  */
 onMounted(() => {
-  loadDataFunction()
+  fetchDataTankWaitingList()
 })
 
 watch(() => bus.value.get('successRegistration'), (val) => {

--- a/src/modules/tanques/composables/useTanqueEspera.js
+++ b/src/modules/tanques/composables/useTanqueEspera.js
@@ -18,6 +18,10 @@ const useTanqueEspera = () => {
     return resp
   }
 
+  const addEntryTank = async (tank) => {
+    return await store.addEntryTankSt(tank)
+  }
+
   const deleteTanqueEspera = async (tank) => {
     const resp = await store.borrarTanqueEspera(tank)
     return resp
@@ -46,6 +50,7 @@ const useTanqueEspera = () => {
     fetchTanksInEspera,
     fetchLastAssignment,
     agregarTanqueEspera,
+    addEntryTank,
     deleteTanqueEspera,
     updateTankPosition,
     getTanquesInEspera,

--- a/src/modules/tanques/store/tanquesStore.js
+++ b/src/modules/tanques/store/tanquesStore.js
@@ -135,6 +135,15 @@ export const useTanqueStore = defineStore('tanques', {
       }
     },
 
+    async addEntryTankSt(tank) {
+      try {
+        const res = await scadaApi.post('tanques/entrada', tank)
+        return res
+      } catch (error) {
+        return { ok: false, message: error.message }
+      }
+    },
+
     async borrarTanqueEspera(tank) {
       try {
         const res = await scadaApi.delete(`tanques/espera/${tank.id}`)


### PR DESCRIPTION
Se agrego funcion de enviar a dos endpoints diferentes al mismo tiempo.
Se elimino uso de store en componentes de últimas cargas, entradas y lista de espera.
Se agrego actualización de tabla de entradas, al momento de registrar una.


[Changes reviewed on CodeStream](https://api.codestream.com/r/YbPM4gTeRRLdpfdq/2udtY0wgRv2uQTFwx54yJw?src=GitHub) by ducter-dev on Mar 14, 2023

**This PR Addresses:**  
[SIN-97 Cambiar ruta de formulario agregar entrada manual](https://ducter-development.atlassian.net/browse/SIN-97)  


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>